### PR TITLE
1st commit. Using mariadb and not mysql

### DIFF
--- a/saki8093/week-9-compose-files/Dockerfile
+++ b/saki8093/week-9-compose-files/Dockerfile
@@ -1,0 +1,5 @@
+FROM php:7.0-apache
+RUN docker-php-ext-install mysqli && docker-php-ext-enable mysqli 
+COPY ./web /var/www/html/
+WORKDIR  /var/www/html
+

--- a/saki8093/week-9-compose-files/README.md
+++ b/saki8093/week-9-compose-files/README.md
@@ -1,0 +1,26 @@
+This project involves the creation of a robust web application. It makes use of 4 dockerised containers. They are
+	a) A centos/httpd load balancer
+	b) Two php:7.0 apache web servers
+	c) A mysql database server.
+	
+Make sure you have all the directories and files saved in the same structure as in this repository. The outermost Dockerfile is used to setup and configure the webservers. The Dockerfile within the "lb" directory is used to configure the centos/httpd load balancer. 
+
+In order to change the php script, go to the "web" directory and change the "index.php" file as you wish. Note: mysqli is installed and enabled. 
+
+In order to change the contents of the database (named "cloud"), go the the "dbdata" directory and change the contents of the "basic.sql" sql file. As of right now, the sql file just adds a few simple entries into a table called "basic". 
+
+The two php-apache web server containers listen on port 80 (on the container). The ports on the host that connect to the container ports are randomly chosen. 
+
+The load balancing container listens on port 80 on the container and port 8080 on the host name. So in order to access the web servers' contents, you need to enter "http://localhost:8080/index.php" (or replace localhost with your current LAN ip address). 
+
+The database server listens on port 3306  on the container. The port on the host that connects to this container port is randomly chosen. 
+
+In order to use the docker application, make sure you have the docker daemon turned on. This can be done using "systemctl start docker". To run the docker-compose file, go to the directory where the "docker-compose.yml" file is present and hit "docker-compose up --build"
+
+In order to check the status of the load balancer, go to "http://localhost:8080/balancer-manager. The web page shows a list of all the web servers and how many requests each web server has received up until the current time.
+
+For more information about this project, you can reach me at saki8093@colorado.edu or samkishan@icloud.com
+
+
+
+Latest modifications done on 15/04/2018

--- a/saki8093/week-9-compose-files/dbdata/basic.sql
+++ b/saki8093/week-9-compose-files/dbdata/basic.sql
@@ -1,0 +1,7 @@
+CREATE TABLE cloud.basic (name VARCHAR(20), age INT, location VARCHAR(20));
+INSERT INTO  cloud.basic VALUES ("Goku", 33, "Tokyo");
+INSERT INTO  cloud.basic VALUES ("Gohna", 17, "Kyoto");
+INSERT INTO  cloud.basic VALUES ("Vegeta", 33, "Saiyan planet");
+INSERT INTO  cloud.basic VALUES ("Piccolo", 400, "Namake");
+GRANT ALL ON cloud.* to 'root'@'172.18.0.2' identified by 'password';
+GRANT ALL ON cloud.* to 'root'@'172.18.0.3' identified by 'password';

--- a/saki8093/week-9-compose-files/docker-compose.yml
+++ b/saki8093/week-9-compose-files/docker-compose.yml
@@ -1,0 +1,52 @@
+version: '3.1'
+services:
+  web3_1:
+    container_name: web1_3
+    build: .
+    ports:
+     - "80"
+    networks:
+      test:
+        ipv4_address: 172.28.0.2
+  web3_2:
+    container_name: web2_3
+    build: . 
+    ports: 
+     - "80" 
+    networks:
+      test:
+        ipv4_address: 172.28.0.3
+  lb3_2:
+    container_name: lb_3
+    build: ./lb 
+    ports:
+     - "8080:80"
+    networks:
+      test:
+        ipv4_address: 172.28.0.4
+  
+  db3_2:
+    container_name: db_3
+    image: mariadb
+    environment: 
+       MYSQL_ROOT_PASSWORD: password
+       MYSQL_DATABASE: cloud
+       MYSQL_PASSWORD: password
+    volumes:
+       - ./dbdata/basic.sql:/docker-entrypoint-initdb.d/basic.sql
+    ports:
+      - "3306"
+    networks: 
+      test:
+        ipv4_address: 172.28.0.5
+        
+
+networks:
+   test:
+       ipam:
+           driver: default
+           config: 
+               - subnet: 172.28.0.0/16
+
+volumes:
+ dbdata: 

--- a/saki8093/week-9-compose-files/lb/Dockerfile
+++ b/saki8093/week-9-compose-files/lb/Dockerfile
@@ -1,0 +1,5 @@
+FROM centos/httpd:latest
+ADD ./lb_inner /etc/httpd/conf.d/
+WORKDIR /etc/httpd/conf.d/
+ 
+

--- a/saki8093/week-9-compose-files/lb/lb_inner/lb.conf
+++ b/saki8093/week-9-compose-files/lb/lb_inner/lb.conf
@@ -1,0 +1,13 @@
+ProxyRequests off
+<Proxy balancer://webfarm>
+  BalancerMember http://172.28.0.2:80
+  BalancerMember http://172.28.0.3:80
+  ProxySet lbmethod=byrequests
+</Proxy>
+
+<Location /balancer-manager>
+  SetHandler balancer-manager
+</Location>
+
+ProxyPass /balancer-manager !
+ProxyPass / balancer://webfarm/

--- a/saki8093/week-9-compose-files/web/ind2.php
+++ b/saki8093/week-9-compose-files/web/ind2.php
@@ -1,0 +1,3 @@
+<?php
+echo "Hello world";
+?>

--- a/saki8093/week-9-compose-files/web/index.php
+++ b/saki8093/week-9-compose-files/web/index.php
@@ -1,0 +1,22 @@
+<?php
+echo "<html><title> Cloud Tech assignment </title>";
+echo "<head> Cloud Technologies assignemnt week 8 </head>";
+echo "<body> <br><br> <center> This docker network has a load balancer which redirects traffic to two web containerised servers which is connected to a secure MySQL database server";
+echo "<br><br><br><table name=\"students\" border=\"1\">";
+echo "<tr> <th> Name </th> <th> Age </th> <th> Location </th> </tr>";
+$hostname="db_3";
+$mysqli = mysqli_connect($hostname, "root", "password", "cloud", "3306");
+if(mysqli_connect_error())
+{
+	echo "Failed to connect to MySQL: " . mysqli_connect_error();
+}
+$query="SELECT * from basic";
+$result = mysqli_query($mysqli,$query);
+while($row=mysqli_fetch_row($result)){
+        echo "<tr> <td> $row[0] </td>
+                <td> $row[1] </td>
+                <td> $row[2] </td> </tr>";
+}
+echo "</table></body></html>";
+?>
+


### PR DESCRIPTION
I closed the pull request I had on earlier. I made a slight change in my docker-compose.yml file. The database server will be a mariadb image and not a MySQL image as was the case earlier.

Why? I ran the docker-compose.yml file a few days after  the submission was due and to my surprise the the database container was "exiting" during the assignment of privileges. Using mariadb fixes the issue.  